### PR TITLE
Allow to use the extension with PHPSpec 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "phpspec/phpspec": "^4.0"
+        "phpspec/phpspec": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/nagno/Runner/Maintainer/BootstrapMaintainer.php
+++ b/src/nagno/Runner/Maintainer/BootstrapMaintainer.php
@@ -32,7 +32,7 @@ class BootstrapMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ): void {
         $this->bootstrapMage2();
     }
 
@@ -44,7 +44,7 @@ class BootstrapMaintainer implements Maintainer
         Specification $context,
         MatcherManager $matchers,
         CollaboratorManager $collaborators
-    ) {
+    ): void {
     }
 
     /**


### PR DESCRIPTION
Note: **BC break** Requires major version update when releasing this change.